### PR TITLE
Streamline create device

### DIFF
--- a/src/main/java/org/freedesktop/libudev/Device.java
+++ b/src/main/java/org/freedesktop/libudev/Device.java
@@ -16,6 +16,11 @@ import org.freedesktop.libudev.jna.UdevLibrary;
  */
 public class Device implements HasPointer {
 
+    protected static Device create(final Pointer devicePointer) {
+        //FIXME should probably be stored in a field to match the native lib's memory management.
+        return devicePointer == null ? null : new Device(devicePointer);
+    }
+
     /**
      * Create new udev device, and fill in information from the sys device and the udev database entry.
      * The syspath is the absolute path to the device, including the sys mount point.
@@ -26,15 +31,8 @@ public class Device implements HasPointer {
      */
     public static Device newFromSyspath(final LibUdev udev,
                                         final String syspath) {
-
-        final Pointer devicePointer = UdevLibrary.INSTANCE().udev_device_new_from_syspath(udev.getPointer(),
-                                                                                          StringUtil.asPointer(syspath));
-        if (devicePointer == null) {
-            return null;
-        }
-        else {
-            return new Device(devicePointer);
-        }
+        return create(UdevLibrary.INSTANCE().udev_device_new_from_syspath(udev.getPointer(),
+                                                                          StringUtil.asPointer(syspath)));
     }
 
     /**
@@ -50,15 +48,9 @@ public class Device implements HasPointer {
     public static Device newFromDevnum(final LibUdev udev,
                                        final byte type,
                                        final int devnum) {
-        final Pointer devicePointer = UdevLibrary.INSTANCE().udev_device_new_from_devnum(udev.getPointer(),
-                                                                                                type,
-                                                                                                devnum);
-        if (devicePointer == null) {
-            return null;
-        }
-        else {
-            return new Device(devicePointer);
-        }
+        return create(UdevLibrary.INSTANCE().udev_device_new_from_devnum(udev.getPointer(),
+                                                                         type,
+                                                                         devnum));
     }
 
     /**
@@ -74,15 +66,9 @@ public class Device implements HasPointer {
     public static Device newFromSubsystemSysname(final LibUdev udev,
                                                  final String subsystem,
                                                  final String sysname) {
-        final Pointer devicePointer = UdevLibrary.INSTANCE().udev_device_new_from_subsystem_sysname(udev.getPointer(),
-                                                                                                    StringUtil.asPointer(subsystem),
-                                                                                                    StringUtil.asPointer(sysname));
-        if (devicePointer == null) {
-            return null;
-        }
-        else {
-            return new Device(devicePointer);
-        }
+        return create(UdevLibrary.INSTANCE().udev_device_new_from_subsystem_sysname(udev.getPointer(),
+                                                                                    StringUtil.asPointer(subsystem),
+                                                                                    StringUtil.asPointer(sysname)));
     }
 
     /**
@@ -96,14 +82,8 @@ public class Device implements HasPointer {
      */
     public static Device newFromDeviceId(final LibUdev udev,
                                          final String id) {
-        final Pointer devicePointer = UdevLibrary.INSTANCE().udev_device_new_from_device_id(udev.getPointer(),
-                                                                                            StringUtil.asPointer(id));
-        if (devicePointer == null) {
-            return null;
-        }
-        else {
-            return new Device(devicePointer);
-        }
+        return create(UdevLibrary.INSTANCE().udev_device_new_from_device_id(udev.getPointer(),
+                                                                            StringUtil.asPointer(id)));
     }
 
     /**
@@ -115,18 +95,13 @@ public class Device implements HasPointer {
      * @return a new udev device, or NULL, if it does not exist
      */
     public static Device newFromEnvironment(final LibUdev udev) {
-        final Pointer devicePointer = UdevLibrary.INSTANCE().udev_device_new_from_environment(udev.getPointer());
-        if (devicePointer == null) {
-            return null;
-        }
-        else {
-            return new Device(devicePointer);
-        }
+        return create(UdevLibrary.INSTANCE().udev_device_new_from_environment(udev.getPointer()));
     }
 
     private final Pointer pointer;
 
     public Device(final Pointer pointer) {
+        assert pointer != null;
         this.pointer = pointer;
     }
 
@@ -152,14 +127,7 @@ public class Device implements HasPointer {
      * @return a new udev device, or NULL, if it no parent exist.
      */
     public Device getParent() {
-        final Pointer devicePointer = UdevLibrary.INSTANCE().udev_device_get_parent(getPointer());
-        if (devicePointer == null) {
-            return null;
-        }
-        else {
-            //FIXME should probably be stored in a field to match the native lib's memory management.
-            return new Device(devicePointer);
-        }
+        return create(UdevLibrary.INSTANCE().udev_device_get_parent(getPointer()));
     }
 
     /**
@@ -173,16 +141,9 @@ public class Device implements HasPointer {
      */
     public Device getParentWithSubsystemDevtype(final String subsystem,
                                                 final String devtype) {
-        final Pointer devicePointer = UdevLibrary.INSTANCE().udev_device_get_parent_with_subsystem_devtype(getPointer(),
-                                                                                                           StringUtil.asPointer(subsystem),
-                                                                                                           StringUtil.asPointer(devtype));
-        if (devicePointer == null) {
-            return null;
-        }
-        else {
-            //FIXME should probably be stored in a field to match the native lib's memory management.
-            return new Device(devicePointer);
-        }
+        return create(UdevLibrary.INSTANCE().udev_device_get_parent_with_subsystem_devtype(getPointer(),
+                                                                                           StringUtil.asPointer(subsystem),
+                                                                                           StringUtil.asPointer(devtype)));
     }
 
     /**
@@ -373,8 +334,7 @@ public class Device implements HasPointer {
      */
     public String getSysattrValue(final String sysattr) {
         return StringUtil.fromPointer(UdevLibrary.INSTANCE().udev_device_get_sysattr_value(getPointer(),
-                                                                                           StringUtil
-                                                                                                   .asPointer(sysattr)));
+                                                                                           StringUtil.asPointer(sysattr)));
     }
 
     /**

--- a/src/main/java/org/freedesktop/libudev/Enumerate.java
+++ b/src/main/java/org/freedesktop/libudev/Enumerate.java
@@ -24,6 +24,7 @@ public class Enumerate implements HasPointer {
     private final Pointer pointer;
 
     public Enumerate(final Pointer pointer) {
+        assert pointer != null;
         this.pointer = pointer;
     }
 

--- a/src/main/java/org/freedesktop/libudev/HardwareDB.java
+++ b/src/main/java/org/freedesktop/libudev/HardwareDB.java
@@ -24,6 +24,7 @@ public class HardwareDB implements HasPointer {
     private final Pointer pointer;
 
     public HardwareDB(final Pointer pointer) {
+        assert pointer != null;
         this.pointer = pointer;
     }
 

--- a/src/main/java/org/freedesktop/libudev/LibUdev.java
+++ b/src/main/java/org/freedesktop/libudev/LibUdev.java
@@ -23,6 +23,7 @@ public class LibUdev implements HasPointer {
     private final Pointer pointer;
 
     public LibUdev(final Pointer pointer) {
+        assert pointer != null;
         this.pointer = pointer;
     }
 

--- a/src/main/java/org/freedesktop/libudev/ListEntry.java
+++ b/src/main/java/org/freedesktop/libudev/ListEntry.java
@@ -23,10 +23,9 @@ public class ListEntry implements HasPointer {
 
     /**
      * Use static {@link #create(Pointer)} factory method.
-     *
-     * @param pointer
      */
     public ListEntry(final Pointer pointer) {
+        assert pointer != null;
         this.pointer = pointer;
     }
 

--- a/src/main/java/org/freedesktop/libudev/Monitor.java
+++ b/src/main/java/org/freedesktop/libudev/Monitor.java
@@ -19,6 +19,7 @@ public class Monitor implements HasPointer {
     private final Pointer pointer;
 
     public Monitor(final Pointer pointer) {
+        assert pointer != null;
         this.pointer = pointer;
     }
 

--- a/src/main/java/org/freedesktop/libudev/Monitor.java
+++ b/src/main/java/org/freedesktop/libudev/Monitor.java
@@ -12,6 +12,10 @@ import org.freedesktop.libudev.jna.UdevLibrary;
  */
 public class Monitor implements HasPointer {
 
+    public static Monitor create(final Pointer pointer) {
+        return pointer == null ? null : new Monitor(pointer);
+    }
+
     private final Pointer pointer;
 
     public Monitor(final Pointer pointer) {
@@ -38,14 +42,8 @@ public class Monitor implements HasPointer {
      */
     public static Monitor newFromNetlink(final LibUdev udev,
                                          final String name) {
-        final Pointer monitorPointer = UdevLibrary.INSTANCE().udev_monitor_new_from_netlink(udev.getPointer(),
-                                                                                            StringUtil.asPointer(name));
-        if (monitorPointer == null) {
-            return null;
-        }
-        else {
-            return new Monitor(monitorPointer);
-        }
+        return create(UdevLibrary.INSTANCE().udev_monitor_new_from_netlink(udev.getPointer(),
+                                                                           StringUtil.asPointer(name)));
     }
 
     /**
@@ -98,13 +96,7 @@ public class Monitor implements HasPointer {
      * @return a new udev device, or NULL, in case of an error
      */
     public Device receiveDevice() {
-        final Pointer devicePointer = UdevLibrary.INSTANCE().udev_monitor_receive_device(getPointer());
-        if (devicePointer == null) {
-            return null;
-        }
-        else {
-            return new Device(devicePointer);
-        }
+        return Device.create(UdevLibrary.INSTANCE().udev_monitor_receive_device(getPointer()));
     }
 
     /**

--- a/src/main/java/org/freedesktop/libudev/Queue.java
+++ b/src/main/java/org/freedesktop/libudev/Queue.java
@@ -22,6 +22,7 @@ public class Queue implements HasPointer {
     private final Pointer pointer;
 
     public Queue(final Pointer pointer) {
+        assert pointer != null;
         this.pointer = pointer;
     }
 

--- a/src/main/java/org/freedesktop/libudev/Queue.java
+++ b/src/main/java/org/freedesktop/libudev/Queue.java
@@ -16,12 +16,7 @@ public class Queue implements HasPointer {
      */
     public static Queue create(final LibUdev udev) {
         final Pointer queuePointer = UdevLibrary.INSTANCE().udev_queue_new(udev.getPointer());
-        if (queuePointer == null) {
-            return null;
-        }
-        else {
-            return new Queue(queuePointer);
-        }
+        return queuePointer == null ? null : new Queue(queuePointer);
     }
 
     private final Pointer pointer;


### PR DESCRIPTION
Could not help it :)

Only reservation is that I moved comment "should probably be stored in a field to match the native lib's memory management" to Device.create. This comment was at 2 call sites of 7. Is it still relevant?
